### PR TITLE
Added basic rectangle editor support

### DIFF
--- a/PlantUML/UMLComponentDiagramParser.cs
+++ b/PlantUML/UMLComponentDiagramParser.cs
@@ -15,8 +15,8 @@ namespace PlantUML
 
         private static Regex _component = new Regex("^(?:(?:component |database |queue |actor ) *(?:(?<name>[\\w]+)|(?:(?:\\[|\\\")(?<name>[\\w ]+)(?:\\]|\\\")))) *(?:\\[(?<description>[\\s\\w]+)\\])*(?: *as +(?<alias>[\\w]+))* *(?<color>#[\\w]+)*", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static Regex _interface = new Regex("^(\\(\\)|interface)\\s+\\\"*((?<name>[\\w \\\\]+)\\\"*(\\s+as\\s+(?<alias>[\\w]+))|(?<name>[\\w \\\\]+)\\\"*)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static Regex _packageRegex = new Regex("^\\s*(?<type>package|frame|node|cloud|database|node|folder|together) +\\\"*(?<name>[\\w ]+)*\\\"*\\s+as (?<alias>[\\w\\s]+)*\\s+\\{", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(3000));
-        private static Regex _packageRegex2 = new Regex("^\\s*(?<type>package|frame|node|cloud|database|node|folder|together) +\\\"*(?<name>[\\w ]+)*\\\"*\\s+\\{", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(3000));
+        private static Regex _packageRegex = new Regex("^\\s*(?<type>package|frame|node|cloud|database|node|folder|together|rectangle) +\\\"*(?<name>[\\w ]+)*\\\"*\\s+as (?<alias>[\\w\\s]+)*\\s+\\{", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(3000));
+        private static Regex _packageRegex2 = new Regex("^\\s*(?<type>package|frame|node|cloud|database|node|folder|together|rectangle) +\\\"*(?<name>[\\w ]+)*\\\"*\\s+\\{", RegexOptions.Compiled | RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(3000));
         private static Regex _title = new Regex("^title (?<title>.+)$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static Regex composition = new Regex("^\\[*(?<left>[\\w ]+)\\]* +(?<arrow>[\\<\\-\\(\\)o\\[\\]\\#]+(?<direction>[\\w]+)*[\\->\\(\\)o\\[\\]\\#]+) +\\[*(?<right>[\\w ]+)\\]*", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 

--- a/PlantUMLEditor/Controls/ColorCoding.cs
+++ b/PlantUMLEditor/Controls/ColorCoding.cs
@@ -14,7 +14,7 @@ namespace PlantUMLEditor.Controls
         {
              {new Regex("(@startuml|@enduml)", RegexOptions.Compiled) , Colors.Gray},
             {new Regex("^\\s*(class|interface)\\s+.+?{([\\s.\\w\\W]+?)}", RegexOptions.IgnoreCase | RegexOptions.Multiline| RegexOptions.Compiled), Colors.Firebrick },
-                {new Regex("^\\s*(title|class|\\{\\w+\\}|interface|package|together|alt|opt|loop|try|group|catch|break|par|end|enum|participant|actor|control|component|database|boundary|queue|entity|collections|else)\\s+?", RegexOptions.Multiline | RegexOptions.IgnoreCase| RegexOptions.Compiled), Colors.Blue}
+                {new Regex("^\\s*(title|class|\\{\\w+\\}|interface|package|together|alt|opt|loop|try|group|catch|break|par|end|enum|participant|actor|control|component|database|boundary|queue|entity|collections|else|rectangle)\\s+?", RegexOptions.Multiline | RegexOptions.IgnoreCase| RegexOptions.Compiled), Colors.Blue}
         };
 
         private static Dictionary<Regex, (Color, bool)> _mcolorCodes = new Dictionary<Regex, (Color, bool)>()

--- a/PlantUMLEditor/Controls/Indenter.cs
+++ b/PlantUMLEditor/Controls/Indenter.cs
@@ -22,7 +22,7 @@ namespace PlantUMLEditor.Controls
         private static Regex reg = new Regex("\n");
         private static Regex removeSpaces = new Regex(" {2,}", RegexOptions.Compiled);
         private static Regex tab = new Regex("^(alt|opt|loop|try|group|catch|break|par)\\s+", RegexOptions.Compiled);
-        private static Regex tab2 = new Regex("^\\s*(class|interface|package|enum|together|component|database).+\\{", RegexOptions.Compiled);
+        private static Regex tab2 = new Regex("^\\s*(class|interface|package|enum|together|component|database|rectangle).+\\{", RegexOptions.Compiled);
         private static Regex tabReset = new Regex("^else\\s?.*", RegexOptions.Compiled);
         private static Regex tabStop = new Regex("^(\\}|end(?! note))", RegexOptions.Compiled);
 

--- a/UmlTests/UnitTest1.cs
+++ b/UmlTests/UnitTest1.cs
@@ -225,5 +225,28 @@ com1 ----> l
 ";
             var f = await UMLComponentDiagramParser.ReadString(s);
         }
+
+        [Test]
+        public async Task UMLComponentDiagramWithRectangleParserTest()
+        {
+            string s = @"
+@startuml
+rectangle r1 {
+    component com1
+    component com2 as 2
+
+    interface Ilalala as l
+    interface Iread
+
+    com1 --o Iread
+    com2 --( Iread
+
+    com1 ----> l
+}
+
+@enduml";
+
+            var f = await UMLComponentDiagramParser.ReadString(s);
+        }
     }
 }


### PR DESCRIPTION
Rectangle Editor Support:

* `rectangle` is now recognized as a keyword in the editor for coloring purposes
* `rectangle` behaves the same way as a `package` when indenting or auto-formating (`CTRL+K`)
* Unit test added

It's treated as a package.  I'm not sure if the `UMLComponentDiagramParser` change was necessary, but I put it there to be safe.  I can yank it back out if needed.