### PR TITLE
Comment coloring

### DIFF
--- a/PlantUMLEditor/Controls/ColorCoding.cs
+++ b/PlantUMLEditor/Controls/ColorCoding.cs
@@ -13,7 +13,7 @@ namespace PlantUMLEditor.Controls
         private static Dictionary<Regex, Color> _colorCodes = new Dictionary<Regex, Color>()
         {
             {new Regex("(@startuml|@enduml)", RegexOptions.Compiled) , Colors.Coral},
-            {new Regex("^'.+", RegexOptions.Multiline), Colors.Gray },
+            {new Regex("^'.+", RegexOptions.Multiline), Colors.Gray},
             {new Regex("^\\s*(class|interface)\\s+.+?{([\\s.\\w\\W]+?)}", RegexOptions.IgnoreCase | RegexOptions.Multiline| RegexOptions.Compiled), Colors.Firebrick },
             {new Regex("^\\s*(title|class|\\{\\w+\\}|interface|package|together|alt|opt|loop|try|group|catch|break|par|end|enum|participant|actor|control|component|database|boundary|queue|entity|collections|else|rectangle)\\s+?", RegexOptions.Multiline | RegexOptions.IgnoreCase| RegexOptions.Compiled), Colors.Blue}
         };

--- a/PlantUMLEditor/Controls/ColorCoding.cs
+++ b/PlantUMLEditor/Controls/ColorCoding.cs
@@ -12,18 +12,17 @@ namespace PlantUMLEditor.Controls
     {
         private static Dictionary<Regex, Color> _colorCodes = new Dictionary<Regex, Color>()
         {
-             {new Regex("(@startuml|@enduml)", RegexOptions.Compiled) , Colors.Gray},
+            {new Regex("(@startuml|@enduml)", RegexOptions.Compiled) , Colors.Coral},
+            {new Regex("^'.+", RegexOptions.Multiline), Colors.Gray },
             {new Regex("^\\s*(class|interface)\\s+.+?{([\\s.\\w\\W]+?)}", RegexOptions.IgnoreCase | RegexOptions.Multiline| RegexOptions.Compiled), Colors.Firebrick },
-                {new Regex("^\\s*(title|class|\\{\\w+\\}|interface|package|together|alt|opt|loop|try|group|catch|break|par|end|enum|participant|actor|control|component|database|boundary|queue|entity|collections|else|rectangle)\\s+?", RegexOptions.Multiline | RegexOptions.IgnoreCase| RegexOptions.Compiled), Colors.Blue}
+            {new Regex("^\\s*(title|class|\\{\\w+\\}|interface|package|together|alt|opt|loop|try|group|catch|break|par|end|enum|participant|actor|control|component|database|boundary|queue|entity|collections|else|rectangle)\\s+?", RegexOptions.Multiline | RegexOptions.IgnoreCase| RegexOptions.Compiled), Colors.Blue}
         };
 
         private static Dictionary<Regex, (Color, bool)> _mcolorCodes = new Dictionary<Regex, (Color, bool)>()
         {
             {new Regex("^\\s*(participant|actor|database|queue|component|class|interface|enum|boundary|entity)\\s+[a-zA-Z0-9\\<\\>\\, ]+[^\\{]", RegexOptions.Multiline | RegexOptions.IgnoreCase | RegexOptions.Compiled), (Colors.Green, false ) },
-
-               {new Regex("(\\:.+)",  RegexOptions.Compiled | RegexOptions.IgnoreCase), (Colors.Firebrick, false) },
-                {new Regex("^\\s*(?:alt|opt|loop|try|group|catch|break|par|end|else) +?(.+)$", RegexOptions.Multiline | RegexOptions.IgnoreCase| RegexOptions.Compiled), (Colors.Firebrick, false)}
-
+            {new Regex("(\\:.+)",  RegexOptions.Compiled | RegexOptions.IgnoreCase), (Colors.Firebrick, false) },
+            {new Regex("^\\s*(?:alt|opt|loop|try|group|catch|break|par|end|else) +?(.+)$", RegexOptions.Multiline | RegexOptions.IgnoreCase| RegexOptions.Compiled), (Colors.Firebrick, false)}
         };
 
         private static Regex brackets = new Regex("(\\{|\\})", RegexOptions.Compiled | RegexOptions.IgnoreCase);


### PR DESCRIPTION
Added comment coloring.

* `startuml/enduml` are now Coral
* Comments (any line that starts with a `'`, and the entire line) are gray

Also cleaned up some whitespace in the code where regexes were defined for color dictionaries.