### PR TITLE
@@novalidate option

### DIFF
--- a/PlantUML/UMLSequenceDiagramParser.cs
+++ b/PlantUML/UMLSequenceDiagramParser.cs
@@ -117,6 +117,11 @@ namespace PlantUML
                     continue;
                 }
 
+                if (line == "'@@novalidate")
+                {
+                    d.ValidateAgainstClasses = false;
+                }
+
                 if (!started)
                     continue;
 

--- a/PlantUMLEditor/Models/DocumentMessageGenerator.cs
+++ b/PlantUMLEditor/Models/DocumentMessageGenerator.cs
@@ -84,23 +84,26 @@ namespace PlantUMLEditor.Models
                 }
                 if (doc is UMLSequenceDiagram o)
                 {
-                    var items = from z in o.LifeLines
-                                where z.Warning != null
-                                select new { o = doc, f = z };
-
-                    foreach (var i in items)
+                    if (o.ValidateAgainstClasses)
                     {
-                        newMessages.Add(new DocumentMessage()
+                        var items = from z in o.LifeLines
+                                    where z.Warning != null
+                                    select new { o = doc, f = z };
+
+                        foreach (var i in items)
                         {
-                            FileName = i.o.FileName,
-                            Text = i.f.Warning,
-                            LineNumber = i.f.LineNumber,
+                            newMessages.Add(new DocumentMessage()
+                            {
+                                FileName = i.o.FileName,
+                                Text = i.f.Warning,
+                                LineNumber = i.f.LineNumber,
 
-                            Warning = true
-                        });
+                                Warning = true
+                            });
+                        }
+
+                        CheckEntities(o.FileName, o.Entities, o);
                     }
-
-                    CheckEntities(o.FileName, o.Entities, o);
                 }
             }
 

--- a/UMLModels/UMLSequenceDiagram.cs
+++ b/UMLModels/UMLSequenceDiagram.cs
@@ -14,10 +14,13 @@ namespace UMLModels
             LifeLines = new List<UMLSequenceLifeline>();
             Entities = new List<UMLOrderedEntity>();
             FileName = fileName;
+            ValidateAgainstClasses = true;
         }
 
         public List<UMLOrderedEntity> Entities { get; set; }
         public List<UMLSequenceLifeline> LifeLines { get; set; }
+
+        public bool ValidateAgainstClasses { get; set; }
 
         public UMLSequenceConnection AddConnection(UMLSequenceLifeline source, UMLSequenceLifeline to)
         {


### PR DESCRIPTION
Added `'@@novalidate` keyword.  If it appears anywhere in a sequence document, it disables validation against class diagrams.

This was added as a commented line so as not to interfere with PlantUML's parsing.

The entire line must be the keyword.  Example:

```
@startuml
`@@novalidate

participant Foo
participant Bar

foo -> bar
@enduml
```
