### PR TITLE
Error list cleanup

### DIFF
--- a/PlantUMLEditor/MainWindow.xaml
+++ b/PlantUMLEditor/MainWindow.xaml
@@ -669,41 +669,34 @@ AncestorType={x:Type ListBox}}}"></b:CallMethodAction>
             <TabControl Grid.Row="2">
                 <TabItem>
                     <TabItem.Header>Errors</TabItem.Header>
-                    <DataGrid SelectionMode="Single" IsReadOnly="True"
+					<DataGrid SelectionMode="Single" IsReadOnly="True"
                               Grid.Row="2"
                               AutoGenerateColumns="False"  ItemsSource="{Binding Messages}" Margin="{DynamicResource TabHeaderMargin}"  
                            HorizontalContentAlignment="Stretch"
                               
                                  SelectedItem="{Binding SelectedMessage}">
-                        <DataGrid.Columns>
-                            <DataGridTextColumn IsReadOnly="true" Header="File" Binding="{Binding Text}"></DataGridTextColumn>
-                            <DataGridTextColumn IsReadOnly="true" Header="LineNumber" Binding="{Binding LineNumber}"></DataGridTextColumn>
-                            <DataGridTemplateColumn>
-                                <DataGridTemplateColumn.CellTemplate>
-                                    <DataTemplate>
-                                       
-
-                                        <Button x:Name="createMissingMethod" Command="{Binding FixingCommand}" Margin="10,5,10,5" CommandParameter="{Binding}"
+						<DataGrid.Columns>
+							<DataGridTemplateColumn>
+								<DataGridTemplateColumn.CellTemplate>
+									<DataTemplate>
+										<Button x:Name="createMissingMethod" Command="{Binding FixingCommand}" Margin="10,5,10,5" CommandParameter="{Binding}"
                                 Content="Fix" Grid.Column="2"></Button>
-
-                                        <DataTemplate.Triggers>
-                                            <DataTrigger Binding="{Binding IsFixable}" Value="false">
-                                                <DataTrigger.Setters>
-                                                    <Setter TargetName="createMissingMethod" Property="Visibility" Value="Collapsed"></Setter>
-                                                </DataTrigger.Setters>
-                                            </DataTrigger>
-                                        </DataTemplate.Triggers>
-                                    </DataTemplate>
-                                </DataGridTemplateColumn.CellTemplate>
-                            </DataGridTemplateColumn>
-                            
-                            
-                          
-                        </DataGrid.Columns>
-                    </DataGrid>
-                    
-            
-                </TabItem>
+										<DataTemplate.Triggers>
+											<DataTrigger Binding="{Binding IsFixable}" Value="false">
+												<DataTrigger.Setters>
+													<Setter TargetName="createMissingMethod" Property="Visibility" Value="Collapsed"></Setter>
+												</DataTrigger.Setters>
+											</DataTrigger>
+										</DataTemplate.Triggers>
+									</DataTemplate>
+								</DataGridTemplateColumn.CellTemplate>
+							</DataGridTemplateColumn>
+							<DataGridTextColumn IsReadOnly="true" Header="Text" Binding="{Binding Text}"></DataGridTextColumn>
+							<DataGridTextColumn IsReadOnly="true" Header="Line" Binding="{Binding LineNumber}"></DataGridTextColumn>
+							<DataGridTextColumn IsReadOnly="true" Header="File" Binding="{Binding RelativeFileName}"></DataGridTextColumn>
+						</DataGrid.Columns>
+					</DataGrid>
+				</TabItem>
                 <TabItem>
                     <TabItem.Header>Find</TabItem.Header>
                     <Grid>

--- a/PlantUMLEditor/Models/DocumentMessage.cs
+++ b/PlantUMLEditor/Models/DocumentMessage.cs
@@ -13,6 +13,8 @@ namespace PlantUMLEditor.Models
 
         public string FileName { get; set; }
 
+        public string RelativeFileName { get; set; }
+
         public ICommand FixingCommand
         {
             get;

--- a/PlantUMLEditor/Models/DocumentMessageGenerator.cs
+++ b/PlantUMLEditor/Models/DocumentMessageGenerator.cs
@@ -41,7 +41,7 @@ namespace PlantUMLEditor.Models
          
         }
 
-        public async Task Generate()
+        public async Task Generate(string folderBase)
         {
             List<DocumentMessage> newMessages = new List<DocumentMessage>();
 
@@ -58,7 +58,7 @@ namespace PlantUMLEditor.Models
                             FileName = f.FileName,
                             Text = e.Line,
                             LineNumber = e.LineNumber,
-
+                            RelativeFileName = f.FileName.Substring(folderBase.Length + 1),
                             Warning = false
                         });
                     }
@@ -77,7 +77,7 @@ namespace PlantUMLEditor.Models
                             FileName = f2.FileName,
                             Text = e.Value,
                             LineNumber = e.LineNumber,
-
+                            RelativeFileName = f2.FileName.Substring(folderBase.Length + 1),
                             Warning = false
                         });
                     }
@@ -95,12 +95,12 @@ namespace PlantUMLEditor.Models
                             FileName = i.o.FileName,
                             Text = i.f.Warning,
                             LineNumber = i.f.LineNumber,
-
+                            RelativeFileName = i.o.FileName.Substring(folderBase.Length + 1),
                             Warning = true
                         });
                     }
 
-                    CheckEntities(o.FileName, o.Entities, o);
+                    CheckEntities(o.FileName, folderBase, o.Entities, o);
                 }
             }
 
@@ -119,6 +119,7 @@ namespace PlantUMLEditor.Models
                             newMessages.Add(new DocumentMessage()
                             {
                                 FileName = dt.Item2,
+                                RelativeFileName = dt.Item2.Substring(folderBase.Length + 1),
                                 LineNumber = dt.Item1.LineNumber,
                                 Text = r,
                                 IsMissingDataType = true
@@ -139,6 +140,7 @@ namespace PlantUMLEditor.Models
                                 newMessages.Add(new DocumentMessage()
                                 {
                                     FileName = dt.Item2,
+                                    RelativeFileName = dt.Item2.Substring(folderBase.Length + 1),
                                     LineNumber = dt.Item1.LineNumber,
                                     Text = r,
                                     IsMissingDataType = true
@@ -157,6 +159,7 @@ namespace PlantUMLEditor.Models
                                 newMessages.Add(new DocumentMessage()
                                 {
                                     FileName = dt.Item2,
+                                    RelativeFileName = dt.Item2.Substring(folderBase.Length + 1),
                                     LineNumber = dt.Item1.LineNumber,
                                     Text = r,
                                     IsMissingDataType = true
@@ -188,7 +191,7 @@ namespace PlantUMLEditor.Models
                 }
             }
 
-            void CheckEntities(string fileName, List<UMLOrderedEntity> entities, UMLSequenceDiagram o)
+            void CheckEntities(string fileName, string folderBase, List<UMLOrderedEntity> entities, UMLSequenceDiagram o)
             {
                 foreach (var g in entities)
                 {
@@ -197,6 +200,7 @@ namespace PlantUMLEditor.Models
                         newMessages.Add(new DocumentMessage()
                         {
                             FileName = fileName,
+                            RelativeFileName = fileName.Substring(folderBase.Length + 1),
                             LineNumber = g.LineNumber,
                             Text = g.Warning,
                             MissingMethodText = c.Action?.Signature,
@@ -209,7 +213,7 @@ namespace PlantUMLEditor.Models
 
                     if (g is UMLSequenceBlockSection s)
                     {
-                        CheckEntities(fileName, s.Entities, o);
+                        CheckEntities(fileName, folderBase, s.Entities, o);
                     }
                 }
             }

--- a/PlantUMLEditor/Models/MainModel.cs
+++ b/PlantUMLEditor/Models/MainModel.cs
@@ -365,7 +365,7 @@ namespace PlantUMLEditor.Models
               Messages.Clear();
 
               DocumentMessageGenerator documentMessageGenerator = new DocumentMessageGenerator(diagrams, Messages);
-              documentMessageGenerator.Generate();
+              documentMessageGenerator.Generate(_folderBase);
 
               foreach (var d in Messages)
               {


### PR DESCRIPTION
Cleaned up the error list:

* Renamed `File` column to `Text`
* Added `File` column for relative file names
  * Relative file name is the location of the file relative to the root folder that was scanned
  * Examples:
    * `c:\diagrams\main.class.puml` -> `main.class.puml`
    * `c:\diagrams\seq\main.seq.puml` -> `seq\main.seq.puml`
* Reordered columns
  * Fix button
  * Text
  * Line number
  * Relative file name
