### PR TITLE
Colorizer rewrite

### DIFF
--- a/PlantUML/PlantUML.csproj
+++ b/PlantUML/PlantUML.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Configurations>Debug;Release;Debug (Old Coloring)</Configurations>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PlantUMLEditor.sln
+++ b/PlantUMLEditor.sln
@@ -9,26 +9,35 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlantUML", "PlantUML\PlantU
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UmlTests", "UmlTests\UmlTests.csproj", "{19716CBD-0C34-4D92-A86C-9B580F3ED7AA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UMLModels", "UMLModels\UMLModels.csproj", "{43C31323-38E6-431B-8B4C-A5CF6E9A56A4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UMLModels", "UMLModels\UMLModels.csproj", "{43C31323-38E6-431B-8B4C-A5CF6E9A56A4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug (Old Coloring)|Any CPU = Debug (Old Coloring)|Any CPU
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6969D927-26C4-4DF2-A612-5FC4B16CEAF2}.Debug (Old Coloring)|Any CPU.ActiveCfg = Debug (Old Coloring)|Any CPU
+		{6969D927-26C4-4DF2-A612-5FC4B16CEAF2}.Debug (Old Coloring)|Any CPU.Build.0 = Debug (Old Coloring)|Any CPU
 		{6969D927-26C4-4DF2-A612-5FC4B16CEAF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{6969D927-26C4-4DF2-A612-5FC4B16CEAF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6969D927-26C4-4DF2-A612-5FC4B16CEAF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6969D927-26C4-4DF2-A612-5FC4B16CEAF2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D609106-5D45-4E4A-8A63-62C649681039}.Debug (Old Coloring)|Any CPU.ActiveCfg = Debug (Old Coloring)|Any CPU
+		{0D609106-5D45-4E4A-8A63-62C649681039}.Debug (Old Coloring)|Any CPU.Build.0 = Debug (Old Coloring)|Any CPU
 		{0D609106-5D45-4E4A-8A63-62C649681039}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0D609106-5D45-4E4A-8A63-62C649681039}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0D609106-5D45-4E4A-8A63-62C649681039}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0D609106-5D45-4E4A-8A63-62C649681039}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19716CBD-0C34-4D92-A86C-9B580F3ED7AA}.Debug (Old Coloring)|Any CPU.ActiveCfg = Debug (Old Coloring)|Any CPU
+		{19716CBD-0C34-4D92-A86C-9B580F3ED7AA}.Debug (Old Coloring)|Any CPU.Build.0 = Debug (Old Coloring)|Any CPU
 		{19716CBD-0C34-4D92-A86C-9B580F3ED7AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{19716CBD-0C34-4D92-A86C-9B580F3ED7AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19716CBD-0C34-4D92-A86C-9B580F3ED7AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{19716CBD-0C34-4D92-A86C-9B580F3ED7AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{43C31323-38E6-431B-8B4C-A5CF6E9A56A4}.Debug (Old Coloring)|Any CPU.ActiveCfg = Debug (Old Coloring)|Any CPU
+		{43C31323-38E6-431B-8B4C-A5CF6E9A56A4}.Debug (Old Coloring)|Any CPU.Build.0 = Debug (Old Coloring)|Any CPU
 		{43C31323-38E6-431B-8B4C-A5CF6E9A56A4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{43C31323-38E6-431B-8B4C-A5CF6E9A56A4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43C31323-38E6-431B-8B4C-A5CF6E9A56A4}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/PlantUMLEditor/Controls/Coloring/Colorizer.cs
+++ b/PlantUMLEditor/Controls/Coloring/Colorizer.cs
@@ -1,0 +1,375 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Media;
+
+namespace PlantUMLEditor.Controls.Coloring
+{
+	internal class Colorizer
+	{
+		private const int LINE_SEPARATOR_LENGTH = 2; // \r\n
+
+		public void FormatText(string text, FormattedText formattedText)
+		{
+			int documentOffset = 0;
+			var lines = text.Split("\r\n");
+			for (int i = 0; i < lines.Length; i++)
+			{
+				var line = lines[i];
+				var lineType = DetermineLineType(SplitLine(line));
+				switch (lineType)
+				{
+					case LineType.Comment:
+						documentOffset = ProcessComment(formattedText, line, documentOffset);
+						break;
+
+					case LineType.Declaration:
+						documentOffset = ProcessDeclaration(formattedText, line, documentOffset);
+						break;
+
+					case LineType.DiagramDirection:
+						documentOffset = ProcessDiagramDirection(formattedText, line, documentOffset);
+						break;
+
+					case LineType.Link:
+						documentOffset = ProcessLink(formattedText, line, documentOffset);
+						break;
+
+					case LineType.Normal:
+						documentOffset = ProcessNormal(formattedText, line, documentOffset);
+						break;
+
+					case LineType.Note:
+						var result = ProcessNote(formattedText, lines, documentOffset, i);
+						documentOffset = result.FormattedTextOffset;
+
+						// Notes can span multiple lines, so make sure we skip already-processed lines
+						i = result.LastLineUsedIndex;
+						break;
+
+
+					case LineType.System:
+						documentOffset = ProcessSystem(formattedText, line, documentOffset);
+						break;
+
+					case LineType.Empty:
+					default:
+						documentOffset += line.Length + LINE_SEPARATOR_LENGTH;
+						break;
+
+				}
+			}
+		}
+
+		private LineType DetermineLineType(string[] tokens)
+		{
+			if (tokens.Length == 0)
+			{
+				return LineType.Empty;
+			}
+
+			if ((tokens[0] == "left" || tokens[0] == "top") && tokens[1] == "to")
+			{
+				// top to bottom direction
+				// or
+				// left to right direction
+				return LineType.DiagramDirection;
+			}
+
+			if (tokens[0].StartsWith('\''))
+			{
+				return LineType.Comment;
+			}
+
+			if (Keywords.IsSystemKeyword(tokens[0]))
+			{
+				return LineType.System;
+			}
+
+			if (Keywords.IsDeclaration(tokens[0]))
+			{
+				return LineType.Declaration;
+			}
+
+			if (tokens.Length >= 3 && Keywords.IsArrowIndicator(tokens[1]))
+			{
+				return LineType.Link;
+			}
+
+			if (tokens[0] == "note")
+			{
+				return LineType.Note;
+			}
+
+			return LineType.Normal;
+		}
+
+		private int ProcessNormal(FormattedText text, string line, int documentOffset)
+		{
+			// Format: any line that isn't one of the other types.  Can contain a mixture of keywords
+			// and non-keyword text.  Probably doesn't contain entities.
+			//
+			// Parse the line for keywords only
+
+			// Only need to get this if a keyword is actually found.
+			TextStyle keywordStyle = null;
+
+			documentOffset += GetIndentLevel(line);
+			var parts = new Queue<string>(SplitLine(line));
+			while (parts.Count > 0)
+			{
+				var item = parts.Dequeue();
+				if (Keywords.IsKeyword(item))
+				{
+					if (keywordStyle == null)
+					{
+						keywordStyle = TextStyles.GetStyleForTokenType(TokenType.Keyword);
+					}
+
+					keywordStyle.Apply(text, documentOffset, item.Length);
+				}
+
+				documentOffset += item.Length + (parts.Count == 0 ? LINE_SEPARATOR_LENGTH : 1);
+			}
+
+			return documentOffset;
+		}
+
+		private int ProcessComment(FormattedText text, string line, int offset)
+		{
+			// Format: line starts with a '
+			return ApplyStyleToEntireLine(TokenType.Comment, text, line, offset);
+		}
+
+		private int ProcessSystem(FormattedText text, string line, int offset)
+		{
+			// Format: @startuml or @enduml
+			return ApplyStyleToEntireLine(TokenType.System, text, line, offset);
+		}
+
+		private (int FormattedTextOffset, int LastLineUsedIndex) ProcessNote(FormattedText text, string[] allLines, int documentOffset, int lineIndex)
+		{
+			// Format: starts with "note".
+			// Single-line note: begins with "note" and has a : in the line
+			// Multi-line note: begins with note, and that and all subsequent lines are note until a line appears
+			//		that reads "end note".
+			bool isMultiLine = false;
+			if (allLines[lineIndex].Trim().StartsWith("note") && !allLines[lineIndex].Contains(':'))
+			{
+				// Single-line note
+				isMultiLine = true;
+			}
+
+			documentOffset = ApplyStyleToEntireLine(TokenType.Note, text, allLines[lineIndex], documentOffset);
+
+			if (isMultiLine)
+			{
+				while (lineIndex < allLines.Length)
+				{
+					// Keep going until we either hit "end note" or run out of lines
+					lineIndex++;
+					documentOffset = ApplyStyleToEntireLine(TokenType.Note, text, allLines[lineIndex], documentOffset);
+
+					if (allLines[lineIndex] == "end note")
+					{
+						break;
+					}
+				}
+			}
+
+			return (documentOffset, lineIndex);
+		}
+
+		private int ProcessDeclaration(FormattedText text, string line, int documentOffset)
+		{
+			// TODO: Potential IndexOutOfRange exceptions; needs validation
+
+			// Format: entity_type entity_name as entity_alias {
+			// Everything after entity_name is optional
+
+			documentOffset += GetIndentLevel(line);
+			var lineParts = new Queue<string>(SplitLine(line.Trim()));
+			var entityTypeStyle = TextStyles.GetStyleForTokenType(TokenType.Keyword);
+			var entityNameStyle = TextStyles.GetStyleForTokenType(TokenType.Entity);
+
+			// Part 0 is always the entity type
+			documentOffset = ApplyStyleToNextItem(entityTypeStyle, lineParts, text, documentOffset);
+
+			// Part 1 is always the entity name
+			documentOffset = ApplyStyleToNextItem(entityNameStyle, lineParts, text, documentOffset);
+
+			// We could be done here
+			if (lineParts.Count == 0)
+			{
+				return documentOffset;
+			}
+
+			
+			if (lineParts.Peek() == "as")
+			{
+				// If they exist, parts 2 and 3 are always "as" and the alias
+				documentOffset = ApplyStyleToNextItem(entityTypeStyle, lineParts, text, documentOffset);
+				documentOffset = ApplyStyleToNextItem(entityNameStyle, lineParts, text, documentOffset);
+			}
+
+			// Tack the rest on as normal text
+			if (lineParts.Count > 0)
+			{
+				while (lineParts.Any())
+				{
+					var item = lineParts.Dequeue();
+					documentOffset += item.Length + (lineParts.Count == 0 ? LINE_SEPARATOR_LENGTH : 1);
+				}
+			}
+
+			return documentOffset;
+		}
+
+		private int ProcessLink(FormattedText text, string line, int documentOffset)
+		{
+			// Format: entity_name arrow entity_name : message
+			// The message is optional.
+
+			// TODO: Potential IndexOutOfRange errors
+			var entityStyle = TextStyles.GetStyleForTokenType(TokenType.Entity);
+
+			documentOffset += GetIndentLevel(line);
+			var parts = new Queue<string>(SplitLine(line));
+
+			// Part 0 is always an entity
+			documentOffset = ApplyStyleToNextItem(entityStyle, parts, text, documentOffset);
+
+			// Part 1 is always an arrow and no format is necessary
+			var currentItem = parts.Dequeue();
+			documentOffset += currentItem.Length + (parts.Count == 0 ? LINE_SEPARATOR_LENGTH : 1);
+
+			// Part 2 is always an entity
+			documentOffset = ApplyStyleToNextItem(entityStyle, parts, text, documentOffset);
+
+			if (parts.Count > 0)
+			{
+				// If part 3 is not a colon, just format the rest of the line as normal text
+				TextStyle remainingStyle;
+				if (parts.Peek() == ":")
+				{
+					remainingStyle = TextStyles.GetStyleForTokenType(TokenType.Message);
+				}
+				else
+				{
+					remainingStyle = TextStyles.GetStyleForTokenType(TokenType.Normal);
+				}
+
+				while (parts.Count > 0)
+				{
+					documentOffset = ApplyStyleToNextItem(remainingStyle, parts, text, documentOffset);
+				}
+			}
+
+			return documentOffset;
+		}
+
+		private int ProcessDiagramDirection(FormattedText text, string line, int documentOffset)
+		{
+			// Format: either of the following:
+			//		left to right direction
+			//		top to bottom direction
+			return ApplyStyleToEntireLine(TokenType.Keyword, text, line, documentOffset);
+		}
+
+		private int ApplyStyleToEntireLine(TokenType tokenType, FormattedText text, string line, int documentOffset)
+		{
+			var textStyle = TextStyles.GetStyleForTokenType(tokenType);
+			textStyle.Apply(text, documentOffset, line.Length);
+
+			return documentOffset + line.Length + LINE_SEPARATOR_LENGTH;
+		}
+
+		private int ApplyStyleToNextItem(TextStyle style, Queue<string> itemQueue, FormattedText document, int documentOffset)
+		{
+			// This code appeared EVERYWHERE, so I broke it into its own method.
+			var currentItem = itemQueue.Dequeue();
+			style.Apply(document, documentOffset, currentItem.Length);
+			return documentOffset + currentItem.Length + (itemQueue.Count == 0 ? LINE_SEPARATOR_LENGTH : 1);
+		}
+
+		private int GetIndentLevel(string line)
+		{
+			int indent = 0;
+			while (line[indent] == ' ')
+			{
+				indent++;
+			}
+
+			return indent;
+		}
+
+		private string[] SplitLine(string line)
+		{
+			// Notes:
+			// string.Split() is insufficient, as you can have a single part with spaces in it as long as it's inside
+			// brackets or quotation marks.
+			//
+			// Always trim the line before splitting.  If there are leading spaces the colorizer cares about, line processors
+			// should handle those.
+
+			line = line.Trim();
+
+			if (string.IsNullOrEmpty(line)) return new string[0];
+
+			var retList = new List<string>();
+			var strPos = 0;
+			var isInBracketsOrQuotes = false;
+			var currentWordStart = 0;
+			while (strPos < line.Length)
+			{
+				var c = line[strPos];
+				if (c == '"' && isInBracketsOrQuotes)
+				{
+					isInBracketsOrQuotes = false;
+				}
+				else if (c == '"')
+				{
+					isInBracketsOrQuotes = true;
+				}
+
+				if (c == '[')
+				{
+					isInBracketsOrQuotes = true;
+				}
+
+				if (c == ']')
+				{
+					isInBracketsOrQuotes = false;
+				}
+
+				if (c == ' ')
+				{
+					if (!isInBracketsOrQuotes)
+					{
+						// Edge case: space starts the line.  Just move the next word start along with strPos.
+						// Because we Trim() at the beginning of the method, this should never be hit.  But I'll
+						// leave it here for safety.  Shouldn't affect performance.
+						if (c == 0)
+						{
+							currentWordStart++;
+						}
+						else
+						{
+							var word = line.Substring(currentWordStart, strPos - currentWordStart);
+							retList.Add(word);
+
+							currentWordStart = strPos + 1;
+						}
+					}
+				}
+
+				strPos++;
+			}
+
+			// Add the last word in
+			var finalWord = line.Substring(currentWordStart, line.Length - currentWordStart);
+			retList.Add(finalWord);
+
+			return retList.ToArray();
+		}
+	}
+}

--- a/PlantUMLEditor/Controls/Coloring/Keywords.cs
+++ b/PlantUMLEditor/Controls/Coloring/Keywords.cs
@@ -1,0 +1,116 @@
+﻿using System.Linq;
+
+namespace PlantUMLEditor.Controls.Coloring
+{
+	/// <summary>
+	/// List of keywords PlantUML supports, organized by type.  Note that some types overlap.
+	/// </summary>
+	internal static class Keywords
+	{
+		// Full set of supported keywords
+		private static string[] _keywords = new string[] 
+		{
+			"actor", "alt", "as", "break", "boundary", "catch", "class", "collections", "component", "control", "database", "else", "end",
+			"entity", "enum", "group", "interface", "loop", "of", "opt", "par", "participant", "package", "queue", "rectangle", "title",
+			"together", "try"
+		};
+
+		// System declaration keywords
+		private static string[] _systemKeywords = new string[] { "@startuml", "@enduml" };
+
+		// Anything that indicates a line of some sort:  arrow types and line types.
+		private static char[] _lineIndicators = new char[] { '>', '<', '/', '\\', '^', '#', '*', '+', '{', '}', '(', ')', '.', '-' };
+
+		// Keywords that indicate entity declarations
+		private static string[] _entityKeywords = new string[]
+		{
+			"actor", "boundary", "class", "collections", "component", "control", "database", "entity", "enum", "interface", "package",
+			"participant", "rectangle"
+		};
+
+		/// <summary>
+		/// Determines if a string is a generic PlantUML keyword.
+		/// </summary>
+		/// <param name="candidate">The candidate string.</param>
+		/// <returns>True if it's a keyword; otherwise false.</returns>
+		/// <remarks>
+		///		There is overlap between keywords.  For example, "participant" is both a general keyword and an entity
+		///		declaration keyword.
+		///	</remarks>
+		public static bool IsKeyword(string candidate)
+		{
+			return _keywords.Any(kw => kw == candidate);
+		}
+
+		/// <summary>
+		/// Determines if a string is a system PlantUML keyword.
+		/// </summary>
+		/// <param name="candidate">The candidate string.</param>
+		/// <returns>True if it's a keyword; otherwise false.</returns>
+		/// <remarks>
+		///		System keywords are used to indicate the start and end of a PlantUML document.
+		///		System keywords are not included in the generic keyword list.
+		///	</remarks>
+		public static bool IsSystemKeyword(string candidate)
+		{
+			return _systemKeywords.Any(kw => kw == candidate);
+		}
+
+		/// <summary>
+		/// Determines if a string is a arrow.
+		/// </summary>
+		/// <param name="candidate">The candidate string.</param>
+		/// <returns>True if it's an arrow; otherwise false.</returns>
+		/// <remarks>
+		///		Arrows are the defined here as the lines between entities in various documents.
+		///	</remarks>
+		public static bool IsArrowIndicator(string candidate)
+		{
+			if (candidate.Length == 0) return false;
+			if (_lineIndicators.Any(at => at == candidate[0] || at == candidate.Last()))
+			{
+				return true;
+			}
+
+			// x and o are special cases
+			if (candidate.StartsWith('x') || candidate.StartsWith('o'))
+			{
+				// It's just a stray x or o
+				if (candidate.Length == 1) return false;
+
+				if (_lineIndicators.Any(at => at == candidate[1]))
+				{
+					return true;
+				}
+			}
+
+			if (candidate.EndsWith('x') || candidate.EndsWith('o'))
+			{
+				// Stray x or o
+				if (candidate.Length == 1) return false;
+
+				if (_lineIndicators.Any(at => at == candidate[candidate.Length - 2]))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Determines if a string is an entity declaration keyword.
+		/// </summary>
+		/// <param name="candidate">The candidate string.</param>
+		/// <returns>True if it's a declaration keyword; otherwise false.</returns>
+		/// <remarks>
+		///		There is overlap between keywords.  For example, "participant" is both a general keyword and an entity 
+		///		declaration keyword.
+		///	</remarks>
+
+		public static bool IsDeclaration(string candidate)
+		{
+			return _entityKeywords.Any(ek => ek == candidate);
+		}
+	}
+}

--- a/PlantUMLEditor/Controls/Coloring/LineType.cs
+++ b/PlantUMLEditor/Controls/Coloring/LineType.cs
@@ -1,0 +1,17 @@
+﻿namespace PlantUMLEditor.Controls.Coloring
+{
+	/// <summary>
+	/// Defines different line types for coloring purposes.
+	/// </summary>
+	internal enum LineType
+	{
+		Empty,
+		Comment,
+		Declaration,
+		DiagramDirection,
+		Link,
+		Normal,
+		Note,
+		System
+	}
+}

--- a/PlantUMLEditor/Controls/Coloring/TextStyle.cs
+++ b/PlantUMLEditor/Controls/Coloring/TextStyle.cs
@@ -1,0 +1,40 @@
+﻿using System.Windows;
+using System.Windows.Media;
+
+namespace PlantUMLEditor.Controls.Coloring
+{
+	internal class TextStyle
+	{
+		public TextStyle()
+		{
+			Color = Colors.Black;
+		}
+
+		public Color Color { get; set; }
+
+		public bool IsBold { get; set; }
+
+		public bool IsItalics { get; set; }
+
+		public void Apply(FormattedText text, int start, int length)
+		{
+			// Only do these if they differ from the default; that should save a bunch of work
+			// formatting normal text to normal text.
+
+			if (Color != Colors.Black)
+			{
+				text.SetForegroundBrush(new SolidColorBrush(Color), start, length);
+			}
+
+			if (IsBold)
+			{
+				text.SetFontWeight(FontWeights.Bold, start, length);
+			}
+
+			if (IsItalics)
+			{
+				text.SetFontStyle(FontStyles.Italic, start, length);
+			}
+		}
+	}
+}

--- a/PlantUMLEditor/Controls/Coloring/TextStyles.cs
+++ b/PlantUMLEditor/Controls/Coloring/TextStyles.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Media;
+
+namespace PlantUMLEditor.Controls.Coloring
+{
+	internal static class TextStyles
+	{
+		// Predefined styles.  This could eventually be broken out to a file and parsed if desired.
+		private static Dictionary<TokenType, TextStyle> _mappings = new Dictionary<TokenType, TextStyle>
+		{
+			{ TokenType.Normal, new TextStyle() },
+			{ TokenType.System, new TextStyle { Color = Colors.Coral } },
+			{ TokenType.Comment, new TextStyle { Color = Colors.Gray, IsItalics = true } },
+			{ TokenType.Note, new TextStyle { Color = Colors.Gray } },
+			{ TokenType.Message, new TextStyle { Color = Colors.Firebrick } },
+			{ TokenType.Keyword, new TextStyle { Color = Colors.Blue } },
+			{ TokenType.Entity, new TextStyle { Color = Colors.Green } }
+		};
+
+		public static TextStyle GetStyleForTokenType(TokenType tokenType)
+		{
+			if (!_mappings.TryGetValue(tokenType, out TextStyle result))
+			{
+				result = _mappings[TokenType.Normal];
+			}
+
+			return result;
+		}
+	}
+}

--- a/PlantUMLEditor/Controls/Coloring/TokenType.cs
+++ b/PlantUMLEditor/Controls/Coloring/TokenType.cs
@@ -1,0 +1,16 @@
+﻿namespace PlantUMLEditor.Controls.Coloring
+{
+	/// <summary>
+	/// Available token types for lines.
+	/// </summary>
+	internal enum TokenType
+	{
+		Normal,
+		Comment,
+		Entity,
+		Keyword,
+		Message,
+		Note,
+		System
+	}
+}

--- a/PlantUMLEditor/Controls/MyTextBox.cs
+++ b/PlantUMLEditor/Controls/MyTextBox.cs
@@ -1,10 +1,7 @@
-﻿using PlantUMLEditor.Models;
-using Prism.Commands;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -14,6 +11,9 @@ using System.Windows.Controls.Primitives;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using PlantUMLEditor.Controls.Coloring;
+using PlantUMLEditor.Models;
+using Prism.Commands;
 
 namespace PlantUMLEditor.Controls
 {
@@ -950,7 +950,7 @@ namespace PlantUMLEditor.Controls
  CultureInfo.GetCultureInfo("en-us"),
  FlowDirection.LeftToRight,
  new Typeface(this.FontFamily.Source),
- this.FontSize, Brushes.DarkBlue, VisualTreeHelper.GetDpi(this).PixelsPerDip);
+ this.FontSize, Brushes.Black, VisualTreeHelper.GetDpi(this).PixelsPerDip);
 
             try
             {
@@ -968,9 +968,13 @@ namespace PlantUMLEditor.Controls
             {
                 int end = int.MaxValue;
                 int start = 0;
-
+#if USE_OLD_COLORING
                 ColorCoding coding = new ColorCoding();
                 coding.FormatText(this.TextRead(), formattedText);
+#else
+                Colorizer colorizer = new Colorizer();
+                colorizer.FormatText(this.TextRead(), formattedText);
+#endif
                 lock (_found)
                 {
                     foreach (var item in _found)

--- a/PlantUMLEditor/PlantUMLEditor.csproj
+++ b/PlantUMLEditor/PlantUMLEditor.csproj
@@ -5,6 +5,11 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
+    <Configurations>Debug;Release;Debug (Old Coloring)</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug (Old Coloring)|AnyCPU'">
+    <DefineConstants>TRACE;USE_OLD_COLORING</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PlantUMLEditor/Properties/launchSettings.json
+++ b/PlantUMLEditor/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "PlantUMLEditor": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/UMLModels/UMLModels.csproj
+++ b/UMLModels/UMLModels.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Configurations>Debug;Release;Debug (Old Coloring)</Configurations>
   </PropertyGroup>
 
 </Project>

--- a/UmlTests/UmlTests.csproj
+++ b/UmlTests/UmlTests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <Configurations>Debug;Release;Debug (Old Coloring)</Configurations>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Refactored the text coloring.

* Used a more token-based approach that examines each line for its type then breaks the lines into tokens to be colored individually.
* Created a `TextStyle` class to encompass color, italics, and bold.  The class also applies its style to a given block of text.
* Fleshed out coloring in general to encompass all entities in their appropriate locations, notes, comments, messages, keywords, and system keywords.
* Added a `Debug (Old Coloring)` solution configuration so developers can switch to the old method while debugging if they want.
  * Accomplished by adding a `USE_OLD_COLORING` conditional compilation symbol defined in the PlantUMLEditor project for the `Debug (Old Coloring)` configuration.

Advantages
* Much easier to debug than regular expressions.
* More comprehensive.
* Text styles are encapsulated into a class to make them easier to manage. 
  * This also adds the flexibility to add future ability to serialize and customize text styles if that's ever desired.

Disadvantages
* More code.
* Slower by a factor of 2.
  * This may be at least partially attributable to the fact that it's more feature rich and thus simply does more.
  * On a 1000-line sequence diagram, both old and new methods still ran in under 100ms.  So slower is relative.

Personally, I think the benefits outweigh the drawbacks. :)